### PR TITLE
Transformations, groups, and layers

### DIFF
--- a/src/apps/LayoutBuilder/Canvas/LayoutCanvas.tsx
+++ b/src/apps/LayoutBuilder/Canvas/LayoutCanvas.tsx
@@ -375,7 +375,11 @@ export const LayoutCanvas = (props: LayoutCanvasProps) => {
   };
 
   const outlineGroup = (groupId: string) => {
-    const components = builder.getComponentsInGroup(groupId).map((id) => builder.componentState.components[id]);
+    const isSoloInGroup =
+      builder.groups[groupId].elements.filter((element) => element.type === 'component').length === 1;
+    const components = builder
+      .getComponentsInGroup(groupId, isSoloInGroup)
+      .map((id) => builder.componentState.components[id]);
     const commonBounds = getCommonBounds(components.map((comp) => comp.bounds));
 
     setGroupOutline({

--- a/src/apps/LayoutBuilder/Canvas/LayoutCanvas.tsx
+++ b/src/apps/LayoutBuilder/Canvas/LayoutCanvas.tsx
@@ -1,4 +1,4 @@
-import { batch, createEffect, createMemo, createSignal, For, on, onCleanup, onMount, Show } from 'solid-js';
+import { batch, createEffect, createMemo, createSignal, For, Index, on, onCleanup, onMount, Show } from 'solid-js';
 import { createStore, unwrap } from 'solid-js/store';
 import { Match, Switch } from 'solid-js/web';
 import { useTree } from '~/apps/TreeProvider';
@@ -491,18 +491,18 @@ export const LayoutCanvas = (props: LayoutCanvasProps) => {
       </div>
       {/* Display */}
       <svg id="canvas" ref={setCanvasRef} width="100%" height="100%" class="bg-white" onPointerDown={onDrawStart}>
-        <For each={Object.values(props.components).sort((a, b) => a.layer - b.layer)}>
+        <Index each={Object.values(props.components).sort((a, b) => a.layer - b.layer)}>
           {(comp) => (
             <LayoutComponent
-              {...comp}
-              active={builder.componentState.selected?.includes(comp.id)}
+              {...comp()}
+              active={builder.componentState.selected.includes(comp().id)}
               selectElement={selectElement}
               variant="outline"
               onDragStart={onDragStart}
               passThrough={ctrl()}
             />
           )}
-        </For>
+        </Index>
         <Selection
           active={transformOp() !== 'drag' && props.selectedComponents.length > 0}
           position={selectionPosition()}

--- a/src/apps/LayoutBuilder/Canvas/LayoutCanvas.tsx
+++ b/src/apps/LayoutBuilder/Canvas/LayoutCanvas.tsx
@@ -193,12 +193,7 @@ export const LayoutCanvas = (props: LayoutCanvasProps) => {
         if (selected().length > 1) {
           const commonBounds = getCommonBounds(initialComponents.map((v) => v.bounds));
 
-          let { bottom, height, left, right, top, width } = calculateResize(
-            commonBounds,
-            newMousePos,
-            activeHandle,
-            false
-          );
+          let { bottom, left, right, top } = calculateResize(commonBounds, newMousePos, activeHandle, false);
 
           let scaleX = (right - left) / Math.abs(commonBounds.width);
           let scaleY = (bottom - top) / Math.abs(commonBounds.height);

--- a/src/apps/LayoutBuilder/Canvas/LayoutCanvas.tsx
+++ b/src/apps/LayoutBuilder/Canvas/LayoutCanvas.tsx
@@ -40,6 +40,7 @@ export const LayoutCanvas = (props: LayoutCanvasProps) => {
 
   const [ctrl, setCtrl] = createSignal(false);
   const [shift, setShift] = createSignal(false);
+  const [alt, setAlt] = createSignal(false);
 
   const [transformState, setTransformState] = createStore<TransformState>({
     startMousePos: ZERO_POS,
@@ -213,7 +214,7 @@ export const LayoutCanvas = (props: LayoutCanvasProps) => {
           scaleY,
           width: w,
           height: h,
-        } = calculateResize(commonBounds, newMousePos, activeHandle, shift());
+        } = calculateResize(commonBounds, newMousePos, activeHandle, shift(), alt());
 
         const flipX = scaleX < 0;
         const flipY = scaleY < 0;
@@ -422,6 +423,10 @@ export const LayoutCanvas = (props: LayoutCanvasProps) => {
       setShift(true);
     }
 
+    if (e.altKey) {
+      setAlt(true);
+    }
+
     const group = e.ctrlKey && e.key === 'g';
 
     if (group) {
@@ -446,6 +451,9 @@ export const LayoutCanvas = (props: LayoutCanvasProps) => {
     }
     if (e.key === 'Shift') {
       setShift(false);
+    }
+    if (e.key === 'Alt') {
+      setAlt(false);
     }
   };
 

--- a/src/apps/LayoutBuilder/Canvas/LayoutCanvas.tsx
+++ b/src/apps/LayoutBuilder/Canvas/LayoutCanvas.tsx
@@ -325,13 +325,12 @@ export const LayoutCanvas = (props: LayoutCanvasProps) => {
           index++;
         }
 
-        if (initialComponents.length === 1 && initialComponents[0].groupId) {
-          outlineGroup(initialComponents[0].groupId);
-        }
-
         measureSelection();
       }
 
+      if (initialComponents.length === 1 && initialComponents[0].groupId) {
+        outlineGroup(initialComponents[0].groupId);
+      }
       // Instead of updating the tree after moving each and every selected component,
       // we can only update the tree for the most outer elements in the selection that would need to be updated
       // because of their parent status.
@@ -400,10 +399,11 @@ export const LayoutCanvas = (props: LayoutCanvasProps) => {
       if (!newSelection.length) {
         setSelectionPosition(ZERO_POS);
         setSelectionSize(ZERO_SIZE);
+        setGroupOutline({ position: ZERO_POS, size: ZERO_SIZE });
         return;
       }
 
-      if (!newSelection.length || newSelection.length > 1) {
+      if (newSelection.length > 1) {
         setGroupOutline({ position: ZERO_POS, size: ZERO_SIZE });
       }
 

--- a/src/apps/LayoutBuilder/Canvas/Selection.tsx
+++ b/src/apps/LayoutBuilder/Canvas/Selection.tsx
@@ -21,6 +21,7 @@ export const Selection = (props: SelectionProps) => {
         <g>
           <Show when={props.active}>
             <rect x={0} y={0} width="100%" height="100%" class="outline-blue-6 outline-1 outline-solid" fill="none" />
+            {/* Corners */}
             <circle
               cx={0}
               cy={0}
@@ -47,6 +48,35 @@ export const Selection = (props: SelectionProps) => {
               cy={'100%'}
               r={6}
               class={`comp-handle-blue-40 stroke-white/50 stroke-1 cursor-se-resize hover:(fill-blue-6)`}
+              onPointerDown={props.onHandleClick}
+            />
+            {/* Edges */}
+            <circle
+              cx={'50%'}
+              cy={0}
+              r={6}
+              class={`comp-handle-blue-40 stroke-white/50 stroke-1 cursor-n-resize hover:(fill-blue-6)`}
+              onPointerDown={props.onHandleClick}
+            />
+            <circle
+              cx={'100%'}
+              cy={'50%'}
+              r={6}
+              class={`comp-handle-blue-40 stroke-white/50 stroke-1 cursor-e-resize hover:(fill-blue-6)`}
+              onPointerDown={props.onHandleClick}
+            />
+            <circle
+              cx={'50%'}
+              cy={'100%'}
+              r={6}
+              class={`comp-handle-blue-40 stroke-white/50 stroke-1 cursor-s-resize hover:(fill-blue-6)`}
+              onPointerDown={props.onHandleClick}
+            />
+            <circle
+              cx={0}
+              cy={'50%'}
+              r={6}
+              class={`comp-handle-blue-40 stroke-white/50 stroke-1 cursor-w-resize hover:(fill-blue-6)`}
               onPointerDown={props.onHandleClick}
             />
           </Show>

--- a/src/apps/LayoutBuilder/Highlighter.tsx
+++ b/src/apps/LayoutBuilder/Highlighter.tsx
@@ -76,22 +76,32 @@ export const Highlighter = () => {
       setRaf(true);
       const newMousePos = { x: e.clientX - dragState.startMousePos.x, y: e.clientY - dragState.startMousePos.y };
 
-      const { updatedPos, updatedSize } = calculateResize(
-        dragState.size,
-        dragState.startElPos,
+      const {
+        left: x,
+        top: y,
+        width,
+        height,
+      } = calculateResize(
+        {
+          ...dragState.size,
+          left: dragState.startElPos.x,
+          top: dragState.startElPos.y,
+          right: dragState.startElPos.x + dragState.size.width,
+          bottom: dragState.startElPos.y + dragState.size.height,
+        },
         newMousePos,
         'top-left'
       );
       setSelfState((p) => ({
         ...p,
-        position: updatedPos,
-        size: { width: Math.abs(updatedSize.width), height: Math.abs(updatedSize.height) },
+        position: { x, y },
+        size: { width: Math.abs(width), height: Math.abs(height) },
       }));
       const bounds: Bounds = {
-        top: updatedPos.y - canvasBounds().y,
-        left: updatedPos.x - canvasBounds().x + selfState.offsetPosition.x,
-        right: updatedPos.x - canvasBounds().x + selfState.offsetPosition.x + Math.abs(updatedSize.width),
-        bottom: updatedPos.y - canvasBounds().y + Math.abs(updatedSize.height),
+        top: y - canvasBounds().y,
+        left: x - canvasBounds().x + selfState.offsetPosition.x,
+        right: x - canvasBounds().x + selfState.offsetPosition.x + Math.abs(width),
+        bottom: y - canvasBounds().y + Math.abs(height),
       };
 
       const insideComponents = Object.values(builder.componentState.components).reduce((acc, comp) => {

--- a/src/apps/LayoutBuilder/Highlighter.tsx
+++ b/src/apps/LayoutBuilder/Highlighter.tsx
@@ -106,7 +106,11 @@ export const Highlighter = () => {
 
       const insideComponents = Object.values(builder.componentState.components).reduce((acc, comp) => {
         if (isInside(comp.bounds, bounds)) {
-          acc.push(comp.id);
+          if (comp.groupId) {
+            acc.push(...builder.getComponentsInGroup(comp.groupId));
+          } else if (!acc.includes(comp.id)) {
+            acc.push(comp.id);
+          }
         }
         return acc;
       }, [] as string[]);

--- a/src/apps/LayoutBuilder/Layers/Layers.tsx
+++ b/src/apps/LayoutBuilder/Layers/Layers.tsx
@@ -11,19 +11,27 @@ interface LayersProps {
 const Layers = (props: LayersProps) => {
   const builder = useBuilder();
 
+  const sendToBack = () => {
+    builder.layerControls.sendToBack(builder.componentState.selected[0]);
+  };
+
   const sendBackward = () => {
-    if (props.selectedComponents?.length === 1) {
-      builder.layerControls.sendBackward(props.selectedComponents[0].id);
+    if (props.selectedComponents.length) {
+      builder.layerControls.sendBackward(builder.componentState.selected[0]);
     }
   };
 
   const bringForward = () => {
-    if (props.selectedComponents) {
-      builder.layerControls.bringForward(props.selectedComponents[0].id);
+    if (props.selectedComponents.length) {
+      builder.layerControls.bringForward(builder.componentState.selected[0]);
     }
   };
 
-  const isComponentActive = (id: string) => builder.componentState.selected?.includes(id);
+  const bringToFront = () => {
+    builder.layerControls.bringToFront(builder.componentState.selected[0]);
+  };
+
+  const isComponentActive = (id: string) => builder.componentState.selected.includes(id);
   const anySelected = () => props.selectedComponents;
 
   const sortedComponents = createMemo(() => Object.values(props.components).sort((a, b) => b.layer - a.layer));
@@ -32,7 +40,15 @@ const Layers = (props: LayersProps) => {
     <div class="flex flex-col bg-dark-5 w-72 p-2 h-full mb-4">
       <div class="flex justify-between items-center">
         <h1 class="text-lg color-dark-2"> Layers </h1>
-        <div class="flex gap-2 items-center">
+        <div class="flex gap-2 items-center" onMouseDown={(e) => e.preventDefault()}>
+          <button
+            class="appearance-none rounded-md w-8 h-8 bg-dark-3 border-none outline-none color-white cursor-pointer disabled:(cursor-not-allowed bg-dark-4 color-dark-2)"
+            disabled={!anySelected()}
+            title="Send layer to back"
+            onClick={sendToBack}
+          >
+            B
+          </button>
           <button
             class="appearance-none rounded-md w-8 h-8 bg-dark-3 border-none outline-none color-white cursor-pointer disabled:(cursor-not-allowed bg-dark-4 color-dark-2)"
             disabled={!anySelected()}
@@ -48,6 +64,14 @@ const Layers = (props: LayersProps) => {
             onClick={bringForward}
           >
             <BiRegularLayerPlus size={20} />
+          </button>
+          <button
+            class="appearance-none rounded-md w-8 h-8 bg-dark-3 border-none outline-none color-white cursor-pointer disabled:(cursor-not-allowed bg-dark-4 color-dark-2)"
+            disabled={!anySelected()}
+            title="Bring layer to front"
+            onClick={bringToFront}
+          >
+            F
           </button>
         </div>
       </div>

--- a/src/apps/LayoutBuilder/LayoutComponent/LayoutComponent.tsx
+++ b/src/apps/LayoutBuilder/LayoutComponent/LayoutComponent.tsx
@@ -15,6 +15,9 @@ const LayoutComponent = (props: LayoutComponentProps) => {
 
   const builder = useBuilder();
   const selectElement = () => props.selectElement(props.id);
+  const selectGroup = () => {
+    props.groupId && builder.selectMultipleComponents(builder.getComponentsInGroup(props.groupId));
+  };
 
   const [ref, setRef] = createSignal<SVGGElement>();
 
@@ -27,7 +30,7 @@ const LayoutComponent = (props: LayoutComponentProps) => {
     e.stopPropagation();
     if (shift()) {
       if (props.groupId) {
-        builder.selectComponent(props.id);
+        selectElement();
       } else {
         builder.toggleSelect(props.id);
       }
@@ -35,11 +38,10 @@ const LayoutComponent = (props: LayoutComponentProps) => {
     }
     if (!props.active) {
       if (props.groupId) {
-        builder.selectMultipleComponents(builder.getComponentsInGroup(props.groupId));
-        props.onDragStart(e);
-        return;
+        selectGroup();
+      } else {
+        selectElement();
       }
-      selectElement();
     }
 
     props.onDragStart(e);

--- a/src/apps/LayoutBuilder/LayoutComponent/LayoutComponent.tsx
+++ b/src/apps/LayoutBuilder/LayoutComponent/LayoutComponent.tsx
@@ -16,7 +16,7 @@ const LayoutComponent = (props: LayoutComponentProps) => {
   const builder = useBuilder();
   const selectElement = () => props.selectElement(props.id);
   const selectGroup = () => {
-    props.groupId && builder.selectMultipleComponents(builder.getComponentsInGroup(props.groupId));
+    props.groupId && builder.selectGroup(props.groupId);
   };
 
   const [ref, setRef] = createSignal<SVGGElement>();

--- a/src/apps/LayoutBuilder/LayoutComponent/LayoutComponent.tsx
+++ b/src/apps/LayoutBuilder/LayoutComponent/LayoutComponent.tsx
@@ -26,10 +26,14 @@ const LayoutComponent = (props: LayoutComponentProps) => {
     if (builder.toolState.activeTool === 'draw') return;
     e.stopPropagation();
     if (shift()) {
-      builder.toggleSelect(props.id);
+      if (props.groupId) {
+        builder.selectComponent(props.id);
+      } else {
+        builder.toggleSelect(props.id);
+      }
       return;
     }
-    if (!builder.componentState.selected.includes(props.id)) {
+    if (!props.active) {
       if (props.groupId) {
         builder.selectMultipleComponents(builder.getComponentsInGroup(props.groupId));
         props.onDragStart(e);

--- a/src/apps/LayoutBuilder/Preview/views/HtmlView.tsx
+++ b/src/apps/LayoutBuilder/Preview/views/HtmlView.tsx
@@ -1,9 +1,12 @@
 import { For } from 'solid-js';
+import { useTree } from '~/apps/TreeProvider';
 import { useBuilder } from '../..';
 import { TreeViewProps } from './TreeView';
 
 export const HtmlView = (props: TreeViewProps) => {
   const builder = useBuilder();
+  const tree = useTree()!;
+
   const getChildrenLayers = () => props.children.map((val) => props.allLayers[val]);
   const isComponentActive = (id: string) => builder.componentState.selected.includes(id);
   const depthMargin = 12 * props.depth;
@@ -37,7 +40,7 @@ export const HtmlView = (props: TreeViewProps) => {
           {(layer) => (
             <HtmlView
               allLayers={props.allLayers}
-              children={layer.children}
+              children={tree.tree[layer.id].children}
               id={layer.id}
               depth={props.depth + 1}
               layerValue={layer.layer}

--- a/src/apps/LayoutBuilder/index.tsx
+++ b/src/apps/LayoutBuilder/index.tsx
@@ -263,15 +263,20 @@ const LayoutBuilder = () => {
     const commonBounds = getCommonBounds(componentState.selectedComponent.map((v) => v.bounds));
     setGroups(newGroupId, {
       id: newGroupId,
-      bounds: { left: commonBounds.x, top: commonBounds.y, right: commonBounds.right, bottom: commonBounds.bottom },
-      size: { width: commonBounds.right - commonBounds.x, height: commonBounds.bottom - commonBounds.y },
+      bounds: {
+        left: commonBounds.left,
+        top: commonBounds.top,
+        right: commonBounds.right,
+        bottom: commonBounds.bottom,
+      },
+      size: { width: commonBounds.right - commonBounds.left, height: commonBounds.bottom - commonBounds.top },
       components: [...componentState.selected],
     });
     for (const selectedId of componentState.selected) {
       setComponentState('components', selectedId, 'groupId', newGroupId);
       // updateComponentPosition(selectedId, (p) => ({
-      //   x: p.x - commonBounds.x,
-      //   y: p.y - commonBounds.y,
+      //   x: p.x - commonBounds.left,
+      //   y: p.y - commonBounds.top,
       // }));
     }
   };
@@ -284,10 +289,10 @@ const LayoutBuilder = () => {
 
     for (const component of groups[groupId].components) {
       setComponentState('components', component, 'groupId', undefined);
-      updateComponentPosition(component, (p) => ({
-        x: p.x + groupPosition.x,
-        y: p.y + groupPosition.y,
-      }));
+      // updateComponentPosition(component, (p) => ({
+      //   x: p.x + groupPosition.x,
+      //   y: p.y + groupPosition.y,
+      // }));
     }
 
     setGroups(newGroupState);

--- a/src/apps/LayoutBuilder/index.tsx
+++ b/src/apps/LayoutBuilder/index.tsx
@@ -166,19 +166,33 @@ const LayoutBuilder = () => {
   };
 
   const bringToFront = (id: ComponentID) => {
+    const current = getComponent(id);
     const currentMaxLayer = Object.values(componentState.components).reduce(
       (maxLayer, current) => (current.layer > maxLayer.layer ? current : maxLayer),
-      componentState.components[id]
+      current
     );
+
+    if (current.layer === currentMaxLayer.layer) return;
+
+    for (const component of Object.values(componentState.components)) {
+      if (component.layer <= currentMaxLayer.layer && component.id !== id) {
+        setComponentState('components', component.id, 'layer', (p) => p - 1);
+      }
+    }
+
     setComponentState('components', id, 'layer', currentMaxLayer.layer + 1);
     setComponentState('maxLayer', currentMaxLayer.layer + 1);
   };
 
   const sendToBack = (id: ComponentID) => {
+    const current = getComponent(id);
     const currentMinLayer = Object.values(componentState.components).reduce(
       (minLayer, current) => (current.layer < minLayer.layer ? current : minLayer),
-      componentState.components[id]
+      current
     );
+
+    if (current.layer === currentMinLayer.layer) return;
+
     for (const component of Object.values(componentState.components)) {
       if (component.layer >= currentMinLayer.layer && component.id !== id) {
         setComponentState('components', component.id, 'layer', (p) => p + 1);
@@ -190,7 +204,7 @@ const LayoutBuilder = () => {
   const bringForward = (id: ComponentID) => {
     const current = getComponent(id);
     const oneAhead = getComponentWithLayer(current.layer + 1);
-    // Swap layers with component that has layer one larger layer
+    // Swap layers with component that has one larger layer
     if (oneAhead) {
       setComponentState('components', oneAhead.id, 'layer', current.layer);
       setComponentState('components', id, 'layer', (p) => p + 1);

--- a/src/apps/LayoutBuilder/transform.ts
+++ b/src/apps/LayoutBuilder/transform.ts
@@ -1,0 +1,37 @@
+import { e } from 'unocss';
+import { Bounds, Size, XYPosition } from '~/types';
+import { clamp } from '~/utils/math';
+import { calculateDistances } from './snapping';
+
+export const getRelativeTransformedBounds = (
+  parentBounds: Bounds & Size,
+  initialParentBounds: Bounds & Size,
+  elementBounds: Bounds & Size,
+  isFlippedX: boolean,
+  isFlippedY: boolean
+) => {
+  const nx =
+    (isFlippedX ? initialParentBounds.right - elementBounds.right : elementBounds.left - initialParentBounds.left) /
+    initialParentBounds.width;
+  const ny =
+    (isFlippedY ? initialParentBounds.bottom - elementBounds.bottom : elementBounds.top - initialParentBounds.top) /
+    initialParentBounds.height;
+
+  const nw = elementBounds.width / initialParentBounds.width;
+  const nh = elementBounds.height / initialParentBounds.height;
+
+  let newX = parentBounds.left + parentBounds.width * nx;
+  let newY = parentBounds.top + parentBounds.height * ny;
+
+  const width = parentBounds.width * nw;
+  const height = parentBounds.height * nh;
+
+  return {
+    left: newX,
+    top: newY,
+    right: newX + width,
+    bottom: newY + height,
+    width,
+    height,
+  };
+};

--- a/src/apps/LayoutBuilder/utils.ts
+++ b/src/apps/LayoutBuilder/utils.ts
@@ -5,52 +5,54 @@ import { clamp } from '~/utils/math';
 import { ILayoutComponent } from '.';
 
 export function calculateResize(
-  currentSize: Size,
-  currentPos: XYPosition,
+  bounds: Bounds & Size,
   mousePos: XYPosition,
   handle: string,
   handleReverse: boolean = true
 ) {
-  let updatedSize = { ...currentSize };
-  let updatedPos = { ...currentPos };
+  let updatedBounds = { ...bounds };
   if (handle.includes('left')) {
-    let newWidth = currentSize.width - mousePos.x;
-    let newX = currentPos.x + mousePos.x;
+    let newWidth = bounds.width - mousePos.x;
+    let newX = bounds.left + mousePos.x;
     if (newWidth < 0 && handleReverse) {
-      newX = currentPos.x + currentSize.width;
+      newX = bounds.left + bounds.width;
     }
-    updatedSize.width = newWidth;
-    updatedPos.x = newX;
+    updatedBounds.width = newWidth;
+    updatedBounds.left = newX;
   }
 
   if (handle.includes('bottom')) {
-    let newHeight = currentSize.height + mousePos.y;
+    let newHeight = bounds.height + mousePos.y;
     if (newHeight < 0 && handleReverse) {
-      updatedPos.y = currentPos.y + newHeight;
+      updatedBounds.top = bounds.top + newHeight;
     }
-    updatedSize.height = newHeight;
+    updatedBounds.height = newHeight;
   }
 
   if (handle.includes('top')) {
-    let newHeight = currentSize.height - mousePos.y;
-    let newY = currentPos.y + mousePos.y;
+    let newHeight = bounds.height - mousePos.y;
+    let newY = bounds.top + mousePos.y;
     if (newHeight < 0 && handleReverse) {
-      newY = currentSize.height + currentPos.y;
+      newY = bounds.height + bounds.top;
     }
-    updatedSize.height = newHeight;
-    updatedPos.y = newY;
+    updatedBounds.height = newHeight;
+    updatedBounds.top = newY;
   }
 
   if (handle.includes('right')) {
-    let newWidth = currentSize.width + mousePos.x;
+    let newWidth = bounds.width + mousePos.x;
     if (newWidth < 0 && handleReverse) {
-      updatedPos.x = currentPos.x + newWidth;
+      updatedBounds.left = bounds.left + newWidth;
     }
 
-    updatedSize.width = newWidth;
+    updatedBounds.width = newWidth;
   }
 
-  return { updatedSize, updatedPos };
+  return {
+    ...updatedBounds,
+    right: updatedBounds.left + updatedBounds.width,
+    bottom: updatedBounds.top + updatedBounds.height,
+  };
 }
 
 export function isPointInBounds(point: XYPosition, bounds: XYPosition) {
@@ -147,17 +149,17 @@ export function svgToScreen(x: number, y: number, svg: SVGSVGElement) {
 
 export function getCommonBounds(bounds: Bounds[]) {
   const newBounds = bounds.reduce(
-    (acc, curr) => {
-      acc.x = Math.min(acc.x, curr.left);
-      acc.y = Math.min(acc.y, curr.top);
+    (acc: Bounds & Size, curr) => {
+      acc.left = Math.min(acc.left, curr.left);
+      acc.top = Math.min(acc.top, curr.top);
       acc.right = Math.max(acc.right, curr.right);
       acc.bottom = Math.max(acc.bottom, curr.bottom);
-      acc.width = Math.abs(acc.right - acc.x);
-      acc.height = Math.abs(acc.bottom - acc.y);
+      acc.width = Math.abs(acc.right - acc.left);
+      acc.height = Math.abs(acc.bottom - acc.top);
 
-      return acc;
+      return acc as Bounds & Size;
     },
-    { x: Infinity, y: Infinity, right: -Infinity, bottom: -Infinity, width: Infinity, height: Infinity }
+    { left: Infinity, top: Infinity, right: -Infinity, bottom: -Infinity, width: Infinity, height: Infinity }
   );
 
   return newBounds;

--- a/src/apps/LayoutBuilder/utils.ts
+++ b/src/apps/LayoutBuilder/utils.ts
@@ -8,7 +8,8 @@ export function calculateResize(
   bounds: Bounds & Size,
   mousePos: XYPosition,
   handle: Handles,
-  aspectRatioLock: boolean = false
+  aspectRatioLock: boolean = false,
+  scaleFromCenter: boolean = false
 ) {
   let { bottom, left, right, top, width, height } = { ...bounds };
 
@@ -97,6 +98,28 @@ export function calculateResize(
         break;
       }
     }
+  }
+
+  if (scaleFromCenter) {
+    const scaleX = w / (Math.abs(bounds.width) || 1);
+    const scaleY = h / (Math.abs(bounds.height) || 1);
+    const scale = Math.max(scaleX, scaleY);
+
+    const width = bounds.width * scale;
+    const height = bounds.height * scale;
+    const left = bounds.left - (Math.abs(width) - bounds.width) / 2;
+    const top = bounds.top - (Math.abs(height) - bounds.height) / 2;
+
+    return {
+      left,
+      top,
+      bottom: top + height,
+      right: left + width,
+      width,
+      height,
+      scaleX: scale,
+      scaleY: scale,
+    };
   }
 
   if (right < left) {

--- a/src/apps/LayoutBuilder/utils.ts
+++ b/src/apps/LayoutBuilder/utils.ts
@@ -93,7 +93,7 @@ export const closestZero = (nums: number[]) => {
   }, Number.MAX_SAFE_INTEGER);
 };
 
-export function closestCorner(mousePos: XYPosition, elBounds: Bounds) {
+export function closestCorner(mousePos: XYPosition, elBounds: Bounds, offset: number = 10) {
   const distance = {
     top: mousePos.y - elBounds.top,
     left: mousePos.x - elBounds.left,
@@ -101,16 +101,26 @@ export function closestCorner(mousePos: XYPosition, elBounds: Bounds) {
     bottom: mousePos.y - elBounds.bottom,
   };
 
-  if (Math.abs(distance.top) < 10 && Math.abs(distance.left) < 10) {
-    return 'top-left';
-  } else if (Math.abs(distance.top) < 10 && Math.abs(distance.right) < 10) {
-    return 'top-right';
-  } else if (Math.abs(distance.bottom) < 10 && Math.abs(distance.left) < 10) {
-    return 'bottom-left';
-  } else if (Math.abs(distance.bottom) < 10 && Math.abs(distance.right) < 10) {
-    return 'bottom-right';
+  let handle: string[] = [];
+  if (Math.abs(distance.top) < offset) {
+    handle.push('top');
   }
-  return undefined;
+
+  if (Math.abs(distance.bottom) < offset) {
+    handle.push('bottom');
+  }
+
+  if (Math.abs(distance.left) < offset) {
+    handle.push('left');
+  }
+
+  if (Math.abs(distance.right) < offset) {
+    handle.push('right');
+  }
+
+  let finalHandle = handle[0] || handle[1] ? handle.join('-') : undefined;
+
+  return finalHandle;
 }
 
 export function isInside(innerBounds: Bounds, outerBounds: Bounds) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,3 +14,8 @@ export interface Bounds {
   right: number;
   bottom: number;
 }
+
+export type EdgeHandles = 'top' | 'left' | 'right' | 'bottom';
+export type CornerHandles = 'top-left' | 'bottom-left' | 'top-right' | 'bottom-right';
+
+export type Handles = EdgeHandles | CornerHandles;


### PR DESCRIPTION
This PR will update the transformation functionality for resizing components, introduce nested groups, the ability to selected individual components in groups, and add and fix send to back and bring to front layer functionality.

Handles on the edges of components have been added and the ability to resize from the center of a component evenly.
Introduced `Handles` type and added handling for edge handles in `closestCorner` function for getting the handle. Also, cleaned up and updated the `calculateResize` function to handle aspect ratio lock and resizing from center. 